### PR TITLE
1.21.1

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -42,7 +42,7 @@ mod_name=Ultimate Manhunt
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=GNU GPL 3.0
 # The mod version. See https://semver.org/
-mod_version=0.3.0
+mod_version=1.0.0
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/gradle.properties
+++ b/gradle.properties
@@ -42,7 +42,7 @@ mod_name=Ultimate Manhunt
 # The license of the mod. Review your options at https://choosealicense.com/. All Rights Reserved is the default.
 mod_license=GNU GPL 3.0
 # The mod version. See https://semver.org/
-mod_version=0.2.0
+mod_version=0.3.0
 # The group ID for the mod. It is only important when publishing as an artifact to a Maven repository.
 # This should match the base package used for the mod sources.
 # See https://maven.apache.org/guides/mini/guide-naming-conventions.html

--- a/src/main/java/net/laserdiamond/ultimatemanhunt/api/event/UltimateManhuntGameStateEvent.java
+++ b/src/main/java/net/laserdiamond/ultimatemanhunt/api/event/UltimateManhuntGameStateEvent.java
@@ -137,6 +137,8 @@ public abstract class UltimateManhuntGameStateEvent extends Event {
             player.setHealth(player.getMaxHealth());
             player.tickCount = 0; // Reset tick counts
             player.getFoodData().eat(200, 1.0F); // Reset food level
+            UMSoundEvents.stopDetectionSound(player);
+            UMSoundEvents.stopFlatlineSound(player);
             player.getInventory().clearContent(); // Clear items
             if (player.isSpectator())
             {

--- a/src/main/java/net/laserdiamond/ultimatemanhunt/capability/HunterPlayerTracker.java
+++ b/src/main/java/net/laserdiamond/ultimatemanhunt/capability/HunterPlayerTracker.java
@@ -1,0 +1,94 @@
+package net.laserdiamond.ultimatemanhunt.capability;
+
+import net.laserdiamond.ultimatemanhunt.UMGame;
+import net.laserdiamond.ultimatemanhunt.UltimateManhunt;
+import net.laserdiamond.ultimatemanhunt.network.UMPackets;
+import net.laserdiamond.ultimatemanhunt.network.packet.hunter.TrackingSpeedRunnerS2CPacket;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraftforge.common.util.LazyOptional;
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.LogicalSide;
+import net.minecraftforge.fml.common.Mod;
+
+import java.util.List;
+import java.util.UUID;
+
+@Mod.EventBusSubscriber(modid = UltimateManhunt.MODID)
+public class HunterPlayerTracker {
+
+    @SubscribeEvent
+    public static void onPlayerServerTick(TickEvent.PlayerTickEvent event)
+    {
+        if (event.phase == TickEvent.Phase.START || event.side == LogicalSide.CLIENT || !UMGame.State.isGameRunning())
+        {
+            return;
+        }
+        Player player = event.player;
+        Level level = player.level();
+        if (level.isClientSide)
+        {
+            return;
+        }
+        MinecraftServer mcServer = player.getServer();
+        if (mcServer == null || mcServer.getTickCount() % 5 != 0) // Update every 5 ticks! (Any faster could cause server lag)
+        {
+            return;
+        }
+        player.getCapability(UMPlayerCapability.UM_PLAYER).ifPresent(umPlayer ->
+        {
+            if (umPlayer.isHunter())
+            {
+                List<Player> availableTrackingTargets = UMPlayer.getAvailableSpeedRunners(player);
+                if (availableTrackingTargets.isEmpty())
+                {
+                    TrackingSpeedRunnerS2CPacket.sendNonTracking(player);
+                    return;
+                }
+//                for (Player speedRunnerPlayer : availableTrackingTargets)
+//                {
+//                    if (UMPlayer.isSpeedRunnerOnGracePeriodServer(speedRunnerPlayer))
+//                    {
+//                        // Set to track first available player
+//                        continue;
+//                    }
+//
+//                }
+
+                UUID trackedPlayerUUID = umPlayer.getTrackingPlayerUUID(); // The player the hunter is targeting
+                if (trackedPlayerUUID == player.getUUID())
+                {
+                    TrackingSpeedRunnerS2CPacket.sendNonTracking(player); // Attempting to track themselves. End method
+                    return;
+                }
+                Player trackedPlayer = mcServer.getPlayerList().getPlayer(trackedPlayerUUID);
+                if (trackedPlayer == null)
+                {
+                    TrackingSpeedRunnerS2CPacket.sendNonTracking(player); // Player doesn't exist. End method
+                    return;
+                }
+                if (!trackedPlayer.level().isClientSide)
+                {
+                    if (!trackedPlayer.level().dimension().equals(level.dimension()) || UMPlayer.isSpeedRunnerOnGracePeriodServer(trackedPlayer) || !trackedPlayer.isAlive())
+                    {
+                        TrackingSpeedRunnerS2CPacket.sendNonTracking(player); // Player is either not in the same dimension, on grace period, or dead. End method
+                        return;
+                    }
+                    LazyOptional<UMPlayer> trackedPlayerCap = trackedPlayer.getCapability(UMPlayerCapability.UM_PLAYER); // Get hunter capability of tracked player
+                    if (trackedPlayerCap.isPresent()) // Is the capability present?
+                    {
+                        UMPlayer trackedPlayerHunter = trackedPlayerCap.orElse(new UMPlayer(trackedPlayerUUID));
+                        if (!trackedPlayerHunter.isSpeedRunner()) // Is the tracked player NOT a speed runner (Player could change roles while being tracked)
+                        {
+                            TrackingSpeedRunnerS2CPacket.sendNonTracking(player); // Player is a hunter. Do not track, and end method
+                            return;
+                        }
+                    }
+                }
+                UMPackets.sendToPlayer(new TrackingSpeedRunnerS2CPacket(true, trackedPlayer), player); // Hunter is now tracking this player. Send information
+            }
+        });
+    }
+}

--- a/src/main/java/net/laserdiamond/ultimatemanhunt/capability/SpeedRunnerHunterProximity.java
+++ b/src/main/java/net/laserdiamond/ultimatemanhunt/capability/SpeedRunnerHunterProximity.java
@@ -1,0 +1,119 @@
+package net.laserdiamond.ultimatemanhunt.capability;
+
+import net.laserdiamond.laserutils.util.raycast.AbstractRayCast;
+import net.laserdiamond.ultimatemanhunt.UMGame;
+import net.laserdiamond.ultimatemanhunt.UltimateManhunt;
+import net.laserdiamond.ultimatemanhunt.network.UMPackets;
+import net.laserdiamond.ultimatemanhunt.network.packet.speedrunner.SpeedRunnerDistanceFromHunterS2CPacket;
+import net.laserdiamond.ultimatemanhunt.sound.UMSoundEvents;
+import net.minecraft.network.protocol.game.ClientboundSoundPacket;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.sounds.SoundSource;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+import net.minecraftforge.event.TickEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.LogicalSide;
+import net.minecraftforge.fml.common.Mod;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@Mod.EventBusSubscriber(modid = UltimateManhunt.MODID)
+public class SpeedRunnerHunterProximity {
+
+    /**
+     * Detection range for hunters for speed runners
+     */
+    public static final int HUNTER_DETECTION_RANGE = 50;
+
+    @SubscribeEvent
+    public static void trackPlayerDistancesTick(TickEvent.PlayerTickEvent event)
+    {
+        Player player = event.player;
+        if (event.phase == TickEvent.Phase.START || event.side == LogicalSide.CLIENT || !UMGame.State.isGameRunning())
+        {
+            return;
+        }
+
+        Level level = player.level();
+        if (level.isClientSide)
+        {
+            return;
+        }
+        MinecraftServer mcServer = player.getServer();
+        if (mcServer == null)
+        {
+            return;
+        }
+        player.getCapability(UMPlayerCapability.UM_PLAYER).ifPresent(umPlayer ->
+        {
+            if (umPlayer.isSpeedRunner())
+            {
+                if (!player.isAlive() || umPlayer.isSpeedRunnerOnGracePeriodServer())
+                {
+                    SpeedRunnerDistanceFromHunterS2CPacket.sendNotNearHunterPlayer(player);
+                    // Player is dead, so they are no longer near a hunter
+                    // Player could also be on grace period, so do not continue
+                    return;
+                }
+                float distanceToNearestHunter = getDistanceToClosestHunter(player); // Get the distance to the closest hunter for the speed runner
+                if (distanceToNearestHunter != -1) // Is there a nearby hunter?
+                {
+                    if (mcServer.getTickCount() % 5 != 0) // Time to update distance from hunter?
+                    {
+                        UMPackets.sendToPlayer(new SpeedRunnerDistanceFromHunterS2CPacket(distanceToNearestHunter), player);
+                    }
+                    if (distanceToNearestHunter < HUNTER_DETECTION_RANGE) // Is the player near a hunter?
+                    {
+                        if (player instanceof ServerPlayer serverPlayer)
+                        {
+                            int rate = (int) ((distanceToNearestHunter / 12.5) + 6); // Rate ranges from 6 (closest) to 10 (furthest)
+                            if (player.tickCount % rate == 0) // ~180 bpm
+                            {
+                                serverPlayer.connection.send(new ClientboundSoundPacket(UMSoundEvents.HEART_BEAT.getHolder().get(), SoundSource.PLAYERS, player.getX(), player.getY(), player.getZ(), 100, 1.0F, level.getRandom().nextLong()));
+                            }
+                            UMSoundEvents.playDetectionSound(player); // Play detection sound
+                        }
+                    } else if (mcServer.getTickCount() % 5 != 0) // Not close enough to a hunter
+                    {
+                        UMSoundEvents.stopDetectionSound(player);
+                        SpeedRunnerDistanceFromHunterS2CPacket.sendNotNearHunterPlayer(player);
+                    }
+                } else if (mcServer.getTickCount() % 5 != 0) // Not near a hunter
+                {
+                    UMSoundEvents.stopDetectionSound(player);
+                    SpeedRunnerDistanceFromHunterS2CPacket.sendNotNearHunterPlayer(player);
+                }
+            }
+        });
+    }
+
+    private static float getDistanceToClosestHunter(Player speedRunnerPlayer)
+    {
+        float closestDist = -1;
+        Level level = speedRunnerPlayer.level();
+        if (level.isClientSide)
+        {
+            return closestDist;
+        }
+
+        for (Player nearbyPlayer : level.getEntitiesOfClass(Player.class, AbstractRayCast.createBBLivingEntity(speedRunnerPlayer, HUNTER_DETECTION_RANGE), player ->
+        {
+            AtomicBoolean bool = new AtomicBoolean(false);
+            player.getCapability(UMPlayerCapability.UM_PLAYER).ifPresent(umPlayer ->
+            {
+                bool.set(umPlayer.isHunter());
+            });
+            return bool.get();
+        }))
+        {
+            float distance = speedRunnerPlayer.distanceTo(nearbyPlayer); // Distance from the hunter to the speed runner
+            if (closestDist == -1 || distance < closestDist) // Was a previous distance set, or is this distance a closer one?
+            {
+                closestDist = distance; // This is the closest hunter
+            }
+        }
+        return closestDist;
+    }
+}

--- a/src/main/java/net/laserdiamond/ultimatemanhunt/capability/UMPlayer.java
+++ b/src/main/java/net/laserdiamond/ultimatemanhunt/capability/UMPlayer.java
@@ -35,6 +35,24 @@ public class UMPlayer extends AbstractCapabilityData<UMPlayer>
     public static final int MAX_LIVES = 99;
     private static int currentMaxLives = 3;
     private static boolean buffedHunterOnFinalDeath = false;
+    private static double maxHealthBonus = 0.5;
+    private static AttributeModifier.Operation maxHealthModifier = AttributeModifier.Operation.ADD_MULTIPLIED_BASE;
+    private static double armorBonus = 5;
+    private static AttributeModifier.Operation armorBonusModifier = AttributeModifier.Operation.ADD_VALUE;
+    private static double movementSpeedBonus = 0.1;
+    private static AttributeModifier.Operation movementSpeedBonusModifier = AttributeModifier.Operation.ADD_MULTIPLIED_BASE;
+    private static double movementEfficiencyBonus = 0.1;
+    private static AttributeModifier.Operation movementEfficiencyModifier = AttributeModifier.Operation.ADD_MULTIPLIED_BASE;
+    private static double waterMovementEfficiencyBonus = 0.1;
+    private static AttributeModifier.Operation waterMovementEfficiencyModifier = AttributeModifier.Operation.ADD_MULTIPLIED_BASE;
+    private static double miningEfficiencyBonus = 0.15;
+    private static AttributeModifier.Operation miningEfficiencyModifier = AttributeModifier.Operation.ADD_MULTIPLIED_BASE;
+    private static double submergedMiningEfficiencyBonus = 0.15;
+    private static AttributeModifier.Operation submergedMiningEfficiencyModifier = AttributeModifier.Operation.ADD_MULTIPLIED_BASE;
+    private static double attackDamageBonus = 0.25;
+    private static AttributeModifier.Operation attackDamageBonusModifier = AttributeModifier.Operation.ADD_MULTIPLIED_BASE;
+    private static boolean hasInfiniteSaturation = false;
+    private static float passiveRegen = 2;
 
     /**
      * @return The maximum amount of lives speed runners can currently hold
@@ -83,23 +101,294 @@ public class UMPlayer extends AbstractCapabilityData<UMPlayer>
         return true;
     }
 
+    public static double getMaxHealthBonus()
+    {
+        return maxHealthBonus;
+    }
+
+    public static AttributeModifier.Operation getMaxHealthModifier()
+    {
+        return maxHealthModifier;
+    }
+
+    public static double getArmorBonus()
+    {
+        return armorBonus;
+    }
+
+    public static AttributeModifier.Operation getArmorBonusModifier()
+    {
+        return armorBonusModifier;
+    }
+
+    public static double getMovementSpeedBonus()
+    {
+        return movementSpeedBonus;
+    }
+
+    public static AttributeModifier.Operation getMovementSpeedBonusModifier()
+    {
+        return movementSpeedBonusModifier;
+    }
+
+    public static double getMovementEfficiencyBonus()
+    {
+        return movementEfficiencyBonus;
+    }
+
+    public static AttributeModifier.Operation getMovementEfficiencyModifier()
+    {
+        return movementEfficiencyModifier;
+    }
+
+    public static double getWaterMovementEfficiencyBonus()
+    {
+        return waterMovementEfficiencyBonus;
+    }
+
+    public static AttributeModifier.Operation getWaterMovementEfficiencyModifier()
+    {
+        return waterMovementEfficiencyModifier;
+    }
+
+    public static double getMiningEfficiencyBonus()
+    {
+        return miningEfficiencyBonus;
+    }
+
+    public static AttributeModifier.Operation getMiningEfficiencyModifier()
+    {
+        return miningEfficiencyModifier;
+    }
+
+    public static double getSubmergedMiningEfficiencyBonus()
+    {
+        return submergedMiningEfficiencyBonus;
+    }
+
+    public static AttributeModifier.Operation getSubmergedMiningEfficiencyModifier()
+    {
+        return submergedMiningEfficiencyModifier;
+    }
+
+    public static double getAttackDamageBonus()
+    {
+        return attackDamageBonus;
+    }
+
+    public static AttributeModifier.Operation getAttackDamageBonusModifier()
+    {
+        return attackDamageBonusModifier;
+    }
+
+    public static boolean getHasInfiniteSaturation()
+    {
+        return hasInfiniteSaturation;
+    }
+
+    public static float getPassiveRegen()
+    {
+        return passiveRegen;
+    }
+
+
+    public static boolean setMaxHealthBonus(double newHealthBonus)
+    {
+        if (UMGame.State.hasGameBeenStarted())
+        {
+            return false;
+        }
+        maxHealthBonus = newHealthBonus;
+        return true;
+    }
+
+    public static boolean setMaxHealthBonusModifier(AttributeModifier.Operation operation)
+    {
+        if (UMGame.State.hasGameBeenStarted())
+        {
+            return false;
+        }
+        maxHealthModifier = operation;
+        return true;
+    }
+
+    public static boolean setArmorBonus(double newArmorBonus)
+    {
+        if (UMGame.State.hasGameBeenStarted())
+        {
+            return false;
+        }
+        armorBonus = newArmorBonus;
+        return true;
+    }
+
+    public static boolean setArmorBonusModifier(AttributeModifier.Operation operation)
+    {
+        if (UMGame.State.hasGameBeenStarted())
+        {
+            return false;
+        }
+        armorBonusModifier = operation;
+        return true;
+    }
+
+    public static boolean setMovementSpeedBonus(double newSpeedBonus)
+    {
+        if (UMGame.State.hasGameBeenStarted())
+        {
+            return false;
+        }
+        movementSpeedBonus = newSpeedBonus;
+        return true;
+    }
+
+    public static boolean setMovementSpeedBonusModifier(AttributeModifier.Operation operation)
+    {
+        if (UMGame.State.hasGameBeenStarted())
+        {
+            return false;
+        }
+        movementSpeedBonusModifier = operation;
+        return true;
+    }
+
+    public static boolean setMovementEfficiencyBonus(double value)
+    {
+        if (UMGame.State.hasGameBeenStarted())
+        {
+            return false;
+        }
+        movementEfficiencyBonus = value;
+        return true;
+    }
+
+    public static boolean setMovementEfficiencyBonusModifier(AttributeModifier.Operation operation)
+    {
+        if (UMGame.State.hasGameBeenStarted())
+        {
+            return false;
+        }
+        movementEfficiencyModifier = operation;
+        return true;
+    }
+
+    public static boolean setWaterMovementEfficiencyBonus(double value)
+    {
+        if (UMGame.State.hasGameBeenStarted())
+        {
+            return false;
+        }
+        waterMovementEfficiencyBonus = value;
+        return true;
+    }
+
+    public static boolean setWaterMovementEfficiencyBonusModifier(AttributeModifier.Operation operation)
+    {
+        if (UMGame.State.hasGameBeenStarted())
+        {
+            return false;
+        }
+        waterMovementEfficiencyModifier = operation;
+        return true;
+    }
+
+    public static boolean setMiningEfficiencyBonus(double value)
+    {
+        if (UMGame.State.hasGameBeenStarted())
+        {
+            return false;
+        }
+        miningEfficiencyBonus = value;
+        return true;
+    }
+
+    public static boolean setMiningEfficiencyBonusModifier(AttributeModifier.Operation operation)
+    {
+        if (UMGame.State.hasGameBeenStarted())
+        {
+            return false;
+        }
+        miningEfficiencyModifier = operation;
+        return true;
+    }
+
+    public static boolean setSubmergedMiningEfficiencyBonus(double value)
+    {
+        if (UMGame.State.hasGameBeenStarted())
+        {
+            return false;
+        }
+        submergedMiningEfficiencyBonus = value;
+        return true;
+    }
+
+    public static boolean setSubmergedMiningEfficiencyBonusModifier(AttributeModifier.Operation operation)
+    {
+        if (UMGame.State.hasGameBeenStarted())
+        {
+            return false;
+        }
+        submergedMiningEfficiencyModifier = operation;
+        return true;
+    }
+
+    public static boolean setAttackDamageBonus(double newAttackDamage)
+    {
+        if (UMGame.State.hasGameBeenStarted())
+        {
+            return false;
+        }
+        attackDamageBonus = newAttackDamage;
+        return true;
+    }
+
+    public static boolean setAttackDamageBonusModifier(AttributeModifier.Operation operation)
+    {
+        if (UMGame.State.hasGameBeenStarted())
+        {
+            return false;
+        }
+        attackDamageBonusModifier = operation;
+        return true;
+    }
+
+    public static boolean setHasInfiniteSaturation(boolean infiniteSaturation)
+    {
+        if (UMGame.State.hasGameBeenStarted())
+        {
+            return false;
+        }
+        hasInfiniteSaturation = infiniteSaturation;
+        return true;
+    }
+
+    public static boolean setPassiveRegen(float amount)
+    {
+        if (UMGame.State.hasGameBeenStarted())
+        {
+            return false;
+        }
+        passiveRegen = Math.max(0, amount);
+        return true;
+    }
+
     /**
      * @return A {@link HashMultimap} of {@linkplain Attribute attributes} and {@linkplain AttributeModifier attribute modifiers} to be applied to each Hunter
      */
     public static HashMultimap<Holder<Attribute>, AttributeModifier> createHunterAttributes()
     {
         HashMultimap<Holder<Attribute>, AttributeModifier> ret = HashMultimap.create();
-        ret.put(Attributes.MAX_HEALTH, new AttributeModifier(ACTIVE_MODIFIER, 0.5, AttributeModifier.Operation.ADD_MULTIPLIED_BASE));
-        ret.put(Attributes.ARMOR, new AttributeModifier(ACTIVE_MODIFIER, 5, AttributeModifier.Operation.ADD_VALUE));
+        ret.put(Attributes.MAX_HEALTH, new AttributeModifier(ACTIVE_MODIFIER, maxHealthBonus, maxHealthModifier));
+        ret.put(Attributes.ARMOR, new AttributeModifier(ACTIVE_MODIFIER, armorBonus, armorBonusModifier));
 
-        ret.put(Attributes.MOVEMENT_SPEED, new AttributeModifier(ACTIVE_MODIFIER, 0.1, AttributeModifier.Operation.ADD_MULTIPLIED_BASE));
-        ret.put(Attributes.MOVEMENT_EFFICIENCY, new AttributeModifier(ACTIVE_MODIFIER, 0.1, AttributeModifier.Operation.ADD_MULTIPLIED_BASE));
-        ret.put(Attributes.WATER_MOVEMENT_EFFICIENCY, new AttributeModifier(ACTIVE_MODIFIER, 0.1, AttributeModifier.Operation.ADD_MULTIPLIED_BASE));
+        ret.put(Attributes.MOVEMENT_SPEED, new AttributeModifier(ACTIVE_MODIFIER, movementSpeedBonus, movementSpeedBonusModifier));
+        ret.put(Attributes.MOVEMENT_EFFICIENCY, new AttributeModifier(ACTIVE_MODIFIER, movementEfficiencyBonus, movementEfficiencyModifier));
+        ret.put(Attributes.WATER_MOVEMENT_EFFICIENCY, new AttributeModifier(ACTIVE_MODIFIER, waterMovementEfficiencyBonus, waterMovementEfficiencyModifier));
 
-        ret.put(Attributes.MINING_EFFICIENCY, new AttributeModifier(ACTIVE_MODIFIER, 0.15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE));
-        ret.put(Attributes.SUBMERGED_MINING_SPEED, new AttributeModifier(ACTIVE_MODIFIER, 0.15, AttributeModifier.Operation.ADD_MULTIPLIED_BASE));
+        ret.put(Attributes.MINING_EFFICIENCY, new AttributeModifier(ACTIVE_MODIFIER, miningEfficiencyBonus, miningEfficiencyModifier));
+        ret.put(Attributes.SUBMERGED_MINING_SPEED, new AttributeModifier(ACTIVE_MODIFIER, submergedMiningEfficiencyBonus, submergedMiningEfficiencyModifier));
 
-        ret.put(Attributes.ATTACK_DAMAGE, new AttributeModifier(ACTIVE_MODIFIER, 0.25, AttributeModifier.Operation.ADD_MULTIPLIED_BASE));
+        ret.put(Attributes.ATTACK_DAMAGE, new AttributeModifier(ACTIVE_MODIFIER, attackDamageBonus, attackDamageBonusModifier));
 
         return ret;
     }

--- a/src/main/java/net/laserdiamond/ultimatemanhunt/client/hud/SpeedRunnerGracePeriodOverlay.java
+++ b/src/main/java/net/laserdiamond/ultimatemanhunt/client/hud/SpeedRunnerGracePeriodOverlay.java
@@ -21,7 +21,7 @@ public final class SpeedRunnerGracePeriodOverlay implements UMHUDOverlay {
             RenderSystem.depthMask(false);
             RenderSystem.enableBlend();
             RenderSystem.blendFuncSeparate(GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ONE, GlStateManager.SourceFactor.ONE, GlStateManager.DestFactor.ONE);
-            guiGraphics.setColor(0.1F, 0.1F, 0.75F, 1.0F);
+            guiGraphics.setColor(0.1F, 0.1F, 0.3F, 1.0F);
             guiGraphics.blit(GameRenderer.NAUSEA_LOCATION, 0, 0, -90, 0.0F, 0.0F, width, height, width, height);
             guiGraphics.setColor(1.0F, 1.0F, 1.0F, 1.0F);
             RenderSystem.defaultBlendFunc();

--- a/src/main/java/net/laserdiamond/ultimatemanhunt/client/hud/SpeedRunnerHunterDetectionOverlay.java
+++ b/src/main/java/net/laserdiamond/ultimatemanhunt/client/hud/SpeedRunnerHunterDetectionOverlay.java
@@ -25,7 +25,7 @@ public final class SpeedRunnerHunterDetectionOverlay implements UMHUDOverlay {
         {
             if ((distanceFromHunter > -1) && (distanceFromHunter < UMGame.HUNTER_DETECTION_RANGE) && !umPlayer.isSpeedRunnerOnGracePeriodClient()) // Player has to be in hunter detection range, distance cannot be 0, and must not be on grace period
             {
-                float red = -(distanceFromHunter / 110F) + 0.9F;
+                float red = (-(distanceFromHunter / 110F) + 0.9F) / 3.25F;
 
                 RenderSystem.disableDepthTest();
                 RenderSystem.depthMask(false);

--- a/src/main/java/net/laserdiamond/ultimatemanhunt/client/hunter/ClientTrackedSpeedRunner.java
+++ b/src/main/java/net/laserdiamond/ultimatemanhunt/client/hunter/ClientTrackedSpeedRunner.java
@@ -1,6 +1,10 @@
 package net.laserdiamond.ultimatemanhunt.client.hunter;
 
+import net.minecraft.client.Minecraft;
+import net.minecraft.util.Mth;
+import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.Vec3;
+import org.joml.Vector3f;
 
 import java.util.UUID;
 
@@ -9,8 +13,11 @@ public class ClientTrackedSpeedRunner {
     private static boolean speedRunnersPresent;
     private static String playerName;
     private static UUID playerUUID;
-    private static float distance;
-    private static Vec3 position;
+    private static Vector3f position;
+    private static Vector3f oldPosition;
+    private static float eyeHeight;
+    private static long lastUpdateTick;
+    private static long interval = 5;
 
     public static void setSpeedRunnersPresent(boolean speedRunnersPresent)
     {
@@ -42,23 +49,77 @@ public class ClientTrackedSpeedRunner {
         return ClientTrackedSpeedRunner.playerUUID;
     }
 
-    public static void setDistance(float distance)
-    {
-        ClientTrackedSpeedRunner.distance = distance;
-    }
-
-    public static float getDistance()
-    {
-        return ClientTrackedSpeedRunner.distance;
-    }
-
     public static void setPosition(Vec3 position)
     {
-        ClientTrackedSpeedRunner.position = position;
+        ClientTrackedSpeedRunner.position = position.toVector3f();
     }
 
     public static Vec3 getPosition()
     {
-        return ClientTrackedSpeedRunner.position;
+        Vector3f pos = ClientTrackedSpeedRunner.position;
+        if (pos == null)
+        {
+            return new Vec3(0, 0, 0);
+        }
+        return new Vec3(ClientTrackedSpeedRunner.position);
+    }
+
+    public static void setOldPosition(Vec3 position)
+    {
+        ClientTrackedSpeedRunner.oldPosition = position.toVector3f();
+    }
+
+    public static Vec3 getOldPosition()
+    {
+        if (ClientTrackedSpeedRunner.oldPosition != null)
+        {
+            return new Vec3(ClientTrackedSpeedRunner.oldPosition);
+        }
+        return getPosition();
+    }
+
+    public static void setEyeHeight(float eyeHeight)
+    {
+        ClientTrackedSpeedRunner.eyeHeight = eyeHeight;
+    }
+
+    public static float getEyeHeight()
+    {
+        return ClientTrackedSpeedRunner.eyeHeight;
+    }
+
+    public static void setLastUpdateTick(long tick)
+    {
+        ClientTrackedSpeedRunner.lastUpdateTick = tick;
+    }
+
+    public static long getLastUpdateTick()
+    {
+        return ClientTrackedSpeedRunner.lastUpdateTick;
+    }
+
+    public static void setUpdateInterval(long interval)
+    {
+        ClientTrackedSpeedRunner.interval = interval;
+    }
+
+    public static long getUpdateInterval()
+    {
+        return ClientTrackedSpeedRunner.interval;
+    }
+
+    public static Vec3 getLerpedSpeedRunnerPosition(float partialTick)
+    {
+        Vec3 oldPos = getOldPosition();
+        Vec3 currentPos = getPosition();
+        Minecraft mc = Minecraft.getInstance();
+        Level mcLevel = mc.level;
+        if (mcLevel == null)
+        {
+            return currentPos;
+        }
+        long gameTime = mcLevel.getGameTime();
+        float alpha = Mth.clamp((gameTime + partialTick - getLastUpdateTick()) / getUpdateInterval(), 0f, 1f);
+        return oldPos.lerp(currentPos, alpha);
     }
 }

--- a/src/main/java/net/laserdiamond/ultimatemanhunt/commands/ResetHunterTrackerCommand.java
+++ b/src/main/java/net/laserdiamond/ultimatemanhunt/commands/ResetHunterTrackerCommand.java
@@ -1,0 +1,62 @@
+package net.laserdiamond.ultimatemanhunt.commands;
+
+import com.mojang.brigadier.CommandDispatcher;
+import net.laserdiamond.ultimatemanhunt.UMGame;
+import net.laserdiamond.ultimatemanhunt.capability.UMPlayer;
+import net.laserdiamond.ultimatemanhunt.capability.UMPlayerCapability;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.player.Player;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class ResetHunterTrackerCommand {
+
+    public static void register(CommandDispatcher<CommandSourceStack> dispatcher)
+    {
+        dispatcher.register(
+                Commands.literal("resetPlayerTracker")
+                        .requires(ResetHunterTrackerCommand::isEligible)
+                        .executes(context -> ResetHunterTrackerCommand.resetTracker(context.getSource()))
+        );
+    }
+
+    private static boolean isEligible(CommandSourceStack sourceStack)
+    {
+        AtomicBoolean ret = new AtomicBoolean(false);
+        if (sourceStack.getEntity() instanceof Player player)
+        {
+            player.getCapability(UMPlayerCapability.UM_PLAYER).ifPresent(umPlayer ->
+            {
+                if (umPlayer.isHunter() && UMGame.State.isGameRunning())
+                {
+                    ret.set(true);
+                }
+            });
+        }
+        return ret.get();
+    }
+
+    private static int resetTracker(CommandSourceStack sourceStack)
+    {
+        AtomicInteger ret = new AtomicInteger(0);
+
+        if (sourceStack.getEntity() instanceof Player player)
+        {
+            player.getCapability(UMPlayerCapability.UM_PLAYER).ifPresent(umPlayer ->
+            {
+                if (umPlayer.isHunter() && UMGame.State.isGameRunning())
+                {
+                    List<Player> trackablePlayers = UMPlayer.getAvailableSpeedRunners(player);
+                    umPlayer.setPlayerToTrack(0, trackablePlayers.get(0));
+                    ret.getAndIncrement();
+                    player.sendSystemMessage(Component.literal("Tracker reset!"));
+                }
+            });
+        }
+        return ret.get();
+    }
+}

--- a/src/main/java/net/laserdiamond/ultimatemanhunt/commands/ResetHunterTrackerCommand.java
+++ b/src/main/java/net/laserdiamond/ultimatemanhunt/commands/ResetHunterTrackerCommand.java
@@ -59,4 +59,5 @@ public class ResetHunterTrackerCommand {
         }
         return ret.get();
     }
+
 }

--- a/src/main/java/net/laserdiamond/ultimatemanhunt/commands/sub/GameProfileSC.java
+++ b/src/main/java/net/laserdiamond/ultimatemanhunt/commands/sub/GameProfileSC.java
@@ -60,6 +60,7 @@ public final class GameProfileSC extends UltimateManhuntCommands.SubCommand {
         if (UMGameSettingProfileConfig.doesGameProfileFileExist(profileName))
         {
             commandContext.getSource().sendSuccess(() -> Component.literal("Overwrote settings for Game Profile \"" + profileName + "\""), true);
+            new UMGameSettingProfileConfig(profileName).saveSettingsToFile();
             i++;
             return i;
         }

--- a/src/main/java/net/laserdiamond/ultimatemanhunt/commands/sub/HunterBuffsSC.java
+++ b/src/main/java/net/laserdiamond/ultimatemanhunt/commands/sub/HunterBuffsSC.java
@@ -1,0 +1,211 @@
+package net.laserdiamond.ultimatemanhunt.commands.sub;
+
+import com.mojang.brigadier.arguments.BoolArgumentType;
+import com.mojang.brigadier.arguments.DoubleArgumentType;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.builder.LiteralArgumentBuilder;
+import com.mojang.brigadier.context.CommandContext;
+import net.laserdiamond.ultimatemanhunt.UMGame;
+import net.laserdiamond.ultimatemanhunt.capability.UMPlayer;
+import net.laserdiamond.ultimatemanhunt.commands.UltimateManhuntCommands;
+import net.laserdiamond.ultimatemanhunt.util.file.HunterBuffsConfig;
+import net.minecraft.ChatFormatting;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.commands.Commands;
+import net.minecraft.network.chat.Component;
+import net.minecraft.world.entity.ai.attributes.AttributeModifier;
+
+public class HunterBuffsSC extends UltimateManhuntCommands.SubCommand {
+
+    public HunterBuffsSC(LiteralArgumentBuilder<CommandSourceStack> argumentBuilder) {
+        super(argumentBuilder
+                .then(
+                        Commands.literal("hunterBuffs")
+                                .then(
+                                        Commands.literal("setBuffs")
+                                                .then(
+                                                        createBuffArgs("maxHealth", HunterBuffsSC::setMaxHealthBuff)
+                                                )
+                                                .then(
+                                                        createBuffArgs("armor", HunterBuffsSC::setArmorBuff)
+                                                )
+                                                .then(
+                                                        createBuffArgs("movementSpeed", HunterBuffsSC::setSpeedBuff)
+                                                )
+                                                .then(
+                                                        createBuffArgs("attackDamage", HunterBuffsSC::setAttackDamageBuff)
+                                                )
+                                                .then(
+                                                        Commands.literal("saturation")
+                                                                .then(
+                                                                        Commands.argument("has_saturation", BoolArgumentType.bool())
+                                                                                .executes(context -> setSaturationBuff(context, BoolArgumentType.getBool(context, "has_saturation")))
+                                                                )
+                                                )
+                                )
+                                .then(
+                                        Commands.literal("getBuffs")
+                                                .then(
+                                                        Commands.argument("hunter_buffs_profile_name", StringArgumentType.string())
+                                                                .then(
+                                                                        Commands.literal("load")
+                                                                                .executes(context -> loadHunterBuffProfile(context, StringArgumentType.getString(context, "hunter_buffs_profile_name")))
+                                                                )
+                                                                .then(
+                                                                        Commands.literal("save")
+                                                                                .executes(context -> saveHunterBuffProfile(context, StringArgumentType.getString(context, "hunter_buffs_profile_name")))
+                                                                )
+                                                                .then(
+                                                                        Commands.literal("delete")
+                                                                                .executes(context -> deleteHunterBuffProfile(context, StringArgumentType.getString(context, "hunter_buffs_profile_name")))
+                                                                )
+                                                )
+                                )
+                ));
+    }
+
+    private static LiteralArgumentBuilder<CommandSourceStack> createBuffArgs(String name, IBuffFunc buffFunc)
+    {
+        return Commands.literal(name)
+                .then(
+                        Commands.argument("amount", DoubleArgumentType.doubleArg())
+                                .then(
+                                        Commands.literal("modifier")
+                                                .then(
+                                                        Commands.literal("add")
+                                                                .executes(context -> buffFunc.execute(context, DoubleArgumentType.getDouble(context, "amount"), AttributeModifier.Operation.ADD_VALUE))
+                                                )
+                                                .then(
+                                                        Commands.literal("multiplyBase")
+                                                                .executes(context -> buffFunc.execute(context, DoubleArgumentType.getDouble(context, "amount"), AttributeModifier.Operation.ADD_MULTIPLIED_BASE))
+                                                )
+                                                .then(
+                                                        Commands.literal("multiplyTotal")
+                                                                .executes(context -> buffFunc.execute(context, DoubleArgumentType.getDouble(context, "amount"), AttributeModifier.Operation.ADD_MULTIPLIED_TOTAL))
+                                                )
+                                )
+                );
+    }
+
+    private static int loadHunterBuffProfile(CommandContext<CommandSourceStack> commandContext, String profileName)
+    {
+        int i = 0;
+        if (UMGame.State.hasGameBeenStarted())
+        {
+            commandContext.getSource().sendFailure(Component.literal(ChatFormatting.RED + "Cannot load Hunter Buff Profiles when a game has already been started!"));
+            return i;
+        }
+        if (!HunterBuffsConfig.doesHunterBuffFileExist(profileName))
+        {
+            commandContext.getSource().sendFailure(Component.literal(ChatFormatting.RED + "Hunter Buff Profile \"" + profileName + "\" does not exist"));
+            return i;
+        }
+        new HunterBuffsConfig(profileName).applySettingsToGame();
+        commandContext.getSource().sendSuccess(() -> Component.literal("Applied settings from Hunter Buff Profile \"" + profileName + "\" to game"), true);
+        i++;
+        return i;
+    }
+
+    private static int saveHunterBuffProfile(CommandContext<CommandSourceStack> commandContext, String profileName)
+    {
+        int i = 0;
+        if (HunterBuffsConfig.doesHunterBuffFileExist(profileName))
+        {
+            commandContext.getSource().sendSuccess(() -> Component.literal("Overwrote settings for Hunter Buff Profile \"" + profileName + "\""), true);
+            new HunterBuffsConfig(profileName).saveSettingsToFile();
+            i++;
+            return i;
+        }
+        new HunterBuffsConfig(profileName).saveSettingsToFile();
+        commandContext.getSource().sendSuccess(() -> Component.literal("Saved new Hunter Buff Profile \"" + profileName + "\" to file"), true);
+        i++;
+        return i;
+    }
+
+    private static int deleteHunterBuffProfile(CommandContext<CommandSourceStack> commandContext, String profileName)
+    {
+        int i = 0;
+        if (!HunterBuffsConfig.doesHunterBuffFileExist(profileName))
+        {
+            commandContext.getSource().sendFailure(Component.literal(ChatFormatting.RED + "Hunter Buff Profile \"" + profileName + "\" does not exist"));
+            return i;
+        }
+        new HunterBuffsConfig(profileName).deleteFile();
+        commandContext.getSource().sendSuccess(() -> Component.literal("Deleted Hunter Buff Profile \"" + profileName + "\""), true);
+        i++;
+        return i;
+    }
+
+    private static int setMaxHealthBuff(CommandContext<CommandSourceStack> commandContext, double amount, AttributeModifier.Operation operation)
+    {
+        int i = 0;
+        if (UMPlayer.setMaxHealthBonus(amount) && UMPlayer.setMaxHealthBonusModifier(operation))
+        {
+            commandContext.getSource().sendFailure(Component.literal(ChatFormatting.RED + "Cannot change hunter buffs when a game has already been started!"));
+            return i;
+        }
+        commandContext.getSource().sendSuccess(() -> Component.literal("Set max health buff to: " + amount + " " + operation.name()), true);
+        i++;
+        return i;
+    }
+
+    private static int setArmorBuff(CommandContext<CommandSourceStack> commandContext, double amount, AttributeModifier.Operation operation)
+    {
+        int i = 0;
+        if (UMPlayer.setArmorBonus(amount) && UMPlayer.setArmorBonusModifier(operation))
+        {
+            commandContext.getSource().sendFailure(Component.literal(ChatFormatting.RED + "Cannot change hunter buffs when a game has already been started!"));
+            return i;
+        }
+        commandContext.getSource().sendSuccess(() -> Component.literal("Set armor buff to: " + amount + " " + operation.name()), true);
+        i++;
+        return i;
+    }
+
+    private static int setSpeedBuff(CommandContext<CommandSourceStack> commandContext, double amount, AttributeModifier.Operation operation)
+    {
+        int i = 0;
+        if (UMPlayer.setMovementSpeedBonus(amount) && UMPlayer.setMovementSpeedBonusModifier(operation))
+        {
+            commandContext.getSource().sendFailure(Component.literal(ChatFormatting.RED + "Cannot change hunter buffs when a game has already been started!"));
+            return i;
+        }
+        commandContext.getSource().sendSuccess(() -> Component.literal("Set movement speed buff to: " + amount + " " + operation.name()), true);
+        i++;
+        return i;
+    }
+
+    private static int setAttackDamageBuff(CommandContext<CommandSourceStack> commandContext, double amount, AttributeModifier.Operation operation)
+    {
+        int i = 0;
+        if (UMPlayer.setAttackDamageBonus(amount) && UMPlayer.setAttackDamageBonusModifier(operation))
+        {
+            commandContext.getSource().sendFailure(Component.literal(ChatFormatting.RED + "Cannot change hunter buffs when a game has already been started!"));
+            return i;
+        }
+        commandContext.getSource().sendSuccess(() -> Component.literal("Set attack damage buff to: " + amount + " " + operation.name()), true);
+        i++;
+        return i;
+    }
+
+    private static int setSaturationBuff(CommandContext<CommandSourceStack> commandContext, boolean hasSaturation)
+    {
+        int i = 0;
+        if (UMPlayer.setHasInfiniteSaturation(hasSaturation))
+        {
+            commandContext.getSource().sendFailure(Component.literal(ChatFormatting.RED + "Cannot change hunter buffs when a game has already been started!"));
+            return i;
+        }
+        commandContext.getSource().sendSuccess(() -> Component.literal("Set hunter saturation to: " + hasSaturation), true);
+        i++;
+        return i;
+    }
+
+    @FunctionalInterface
+    private interface IBuffFunc
+    {
+
+        int execute(CommandContext<CommandSourceStack> context, double amount, AttributeModifier.Operation operation);
+    }
+
+}

--- a/src/main/java/net/laserdiamond/ultimatemanhunt/event/ForgeEvents.java
+++ b/src/main/java/net/laserdiamond/ultimatemanhunt/event/ForgeEvents.java
@@ -73,6 +73,7 @@ public class ForgeEvents {
 
         MinecraftForge.EVENT_BUS.post(new RegisterManhuntSubCommandEvent(event));
         UltimateManhuntCommands.register(event.getDispatcher());
+        ResetHunterTrackerCommand.register(event.getDispatcher());
     }
 
     @SubscribeEvent
@@ -369,6 +370,20 @@ public class ForgeEvents {
                 umPlayer.sendUpdateFromServerToSelf(player);
             });
         }
+    }
+
+    @SubscribeEvent
+    public static void onDimensionChange(PlayerEvent.PlayerChangedDimensionEvent event)
+    {
+        Player player = event.getEntity();
+        if (player.level().isClientSide)
+        {
+            return;
+        }
+        player.getCapability(UMPlayerCapability.UM_PLAYER).ifPresent(umPlayer ->
+        {
+            umPlayer.sendUpdateFromServerToSelf(player);
+        });
     }
 
     @SubscribeEvent

--- a/src/main/java/net/laserdiamond/ultimatemanhunt/network/packet/game/RemainingPlayerCountS2CPacket.java
+++ b/src/main/java/net/laserdiamond/ultimatemanhunt/network/packet/game/RemainingPlayerCountS2CPacket.java
@@ -26,6 +26,31 @@ public class RemainingPlayerCountS2CPacket extends NetworkPacket {
         this.players = new int[]{speedRunners.size(), hunters.size()};
     }
 
+    public RemainingPlayerCountS2CPacket(Player excludedPlayer)
+    {
+        LinkedList<Player> speedRunners = new LinkedList<>();
+        LinkedList<Player> hunters = new LinkedList<>();
+        UMPlayer.forAllPlayers(
+                (player, umPlayer) -> {
+                    if (player.getUUID() == excludedPlayer.getUUID())
+                    {
+                        return;
+                    }
+                    speedRunners.add(player);
+                },
+                (player, umPlayer) -> {
+                    if (player.getUUID() == excludedPlayer.getUUID())
+                    {
+                        return;
+                    }
+                    hunters.add(player);
+                },
+                (player, umPlayer) -> {},
+                (player, umPlayer) -> {}
+        );
+        this.players = new int[]{speedRunners.size(), hunters.size()};
+    }
+
     public RemainingPlayerCountS2CPacket(FriendlyByteBuf buf)
     {
         this.players = buf.readVarIntArray();

--- a/src/main/java/net/laserdiamond/ultimatemanhunt/sound/UMSoundEvents.java
+++ b/src/main/java/net/laserdiamond/ultimatemanhunt/sound/UMSoundEvents.java
@@ -44,7 +44,7 @@ public class UMSoundEvents {
             if (sm.getSoundTime(player) == 0)
             {
                 Level level = player.level();
-                serverPlayer.connection.send(new ClientboundSoundPacket(HUNTER_DETECTED.getHolder().get(), SoundSource.MUSIC, player.getX(), player.getY(), player.getZ(), 50, 1.0F, level.getRandom().nextLong()));
+                serverPlayer.connection.send(new ClientboundSoundPacket(HUNTER_DETECTED.getHolder().get(), SoundSource.MUSIC, player.getX(), player.getY(), player.getZ(), 2, 1.0F, level.getRandom().nextLong()));
             }
             sm.increment(player);
         }
@@ -66,7 +66,7 @@ public class UMSoundEvents {
         if (player instanceof ServerPlayer serverPlayer)
         {
             Level level = player.level();
-            serverPlayer.connection.send(new ClientboundSoundPacket(HEAT_BEAT_FLATLINE.getHolder().get(), SoundSource.PLAYERS, player.getX(), player.getY(), player.getZ(), 100, 1.0F, level.getRandom().nextLong()));
+            serverPlayer.connection.send(new ClientboundSoundPacket(HEAT_BEAT_FLATLINE.getHolder().get(), SoundSource.PLAYERS, player.getX(), player.getY(), player.getZ(), 3, 1.0F, level.getRandom().nextLong()));
         }
     }
 

--- a/src/main/java/net/laserdiamond/ultimatemanhunt/util/file/HunterBuffsConfig.java
+++ b/src/main/java/net/laserdiamond/ultimatemanhunt/util/file/HunterBuffsConfig.java
@@ -1,0 +1,207 @@
+package net.laserdiamond.ultimatemanhunt.util.file;
+
+import com.google.gson.JsonObject;
+import net.laserdiamond.ultimatemanhunt.UltimateManhunt;
+import net.laserdiamond.ultimatemanhunt.capability.UMPlayer;
+import net.minecraft.world.entity.ai.attributes.AttributeModifier;
+
+import java.io.File;
+
+public final class HunterBuffsConfig extends JsonConfig {
+
+    public static boolean doesHunterBuffFileExist(String fileName) {
+        File file = new File(UltimateManhunt.MODID + File.separator + "hunter_buffs" + File.separator + fileName + ".json");
+        return file.exists();
+    }
+
+    private static JsonObject createValueModifierObj(double value, int modifierId)
+    {
+        JsonObject ret = new JsonObject();
+        ret.addProperty("value", value);
+        ret.addProperty("modifier", modifierId);
+        return ret;
+    }
+
+    public HunterBuffsConfig(String fileName) {
+        super(fileName);
+    }
+
+    public boolean saveSettingsToFile() {
+        JsonObject buffedHunter = new JsonObject();
+
+        JsonObject health = createValueModifierObj(UMPlayer.getMaxHealthBonus(), UMPlayer.getMaxHealthModifier().id());
+
+        JsonObject armor = createValueModifierObj(UMPlayer.getArmorBonus(), UMPlayer.getArmorBonusModifier().id());
+
+        JsonObject speed = createValueModifierObj(UMPlayer.getMovementSpeedBonus(), UMPlayer.getMovementSpeedBonusModifier().id());
+
+        JsonObject movementEfficiency = createValueModifierObj(UMPlayer.getMovementEfficiencyBonus(), UMPlayer.getMovementEfficiencyModifier().id());
+
+        JsonObject waterMovementEfficiency = createValueModifierObj(UMPlayer.getWaterMovementEfficiencyBonus(), UMPlayer.getWaterMovementEfficiencyModifier().id());
+
+        JsonObject miningEfficiency = createValueModifierObj(UMPlayer.getMiningEfficiencyBonus(), UMPlayer.getMiningEfficiencyModifier().id());
+
+        JsonObject submergedMiningEfficiency = createValueModifierObj(UMPlayer.getSubmergedMiningEfficiencyBonus(), UMPlayer.getSubmergedMiningEfficiencyModifier().id());
+
+        JsonObject damage = createValueModifierObj(UMPlayer.getAttackDamageBonus(), UMPlayer.getAttackDamageBonusModifier().id());
+
+        JsonObject saturation = new JsonObject();
+        saturation.addProperty("value", UMPlayer.getHasInfiniteSaturation());
+
+        JsonObject regen = new JsonObject();
+        regen.addProperty("value", UMPlayer.getPassiveRegen());
+
+        buffedHunter.add("health", health);
+        buffedHunter.add("armor", armor);
+        buffedHunter.add("speed", speed);
+        buffedHunter.add("movement_efficiency", movementEfficiency);
+        buffedHunter.add("water_movement_efficiency", waterMovementEfficiency);
+        buffedHunter.add("mining_efficiency", miningEfficiency);
+        buffedHunter.add("submerged_mining_efficiency", submergedMiningEfficiency);
+        buffedHunter.add("damage", damage);
+        buffedHunter.add("saturation", saturation);
+        buffedHunter.add("passive_regen", regen);
+
+        this.jsonObject.add("buffed_hunter", buffedHunter);
+
+        return this.writeJsonToFile();
+    }
+
+    public void applySettingsToGame() {
+        UMPlayer.setMaxHealthBonus(this.getMaxHealthBonus());
+        UMPlayer.setMaxHealthBonusModifier(this.getMaxHealthBonusModifier());
+
+        UMPlayer.setArmorBonus(this.getArmorBonus());
+        UMPlayer.setArmorBonusModifier(this.getArmorBonusModifier());
+
+        UMPlayer.setMovementSpeedBonus(this.getMovementSpeedBonus());
+        UMPlayer.setMovementSpeedBonusModifier(this.getMovementSpeedBonusModifier());
+
+        UMPlayer.setMovementEfficiencyBonus(this.getMovementEfficiencyBonus());
+        UMPlayer.setMovementEfficiencyBonusModifier(this.getMovementEfficiencyBonusModifier());
+
+        UMPlayer.setWaterMovementEfficiencyBonus(this.getWaterMovementEfficiencyBonus());
+        UMPlayer.setWaterMovementEfficiencyBonusModifier(this.getWaterMovementEfficiencyBonusModifier());
+
+        UMPlayer.setMiningEfficiencyBonus(this.getMiningEfficiencyBonus());
+        UMPlayer.setMiningEfficiencyBonusModifier(this.getMiningEfficiencyBonusModifier());
+
+        UMPlayer.setSubmergedMiningEfficiencyBonus(this.getSubmergedMiningEfficiencyBonus());
+        UMPlayer.setSubmergedMiningEfficiencyBonusModifier(this.getSubmergedMiningEfficiencyBonusModifier());
+
+        UMPlayer.setAttackDamageBonus(this.getAttackDamageBonus());
+        UMPlayer.setAttackDamageBonusModifier(this.getAttackDamageBonusModifier());
+
+        UMPlayer.setHasInfiniteSaturation(this.getHasInfiniteSaturation());
+        UMPlayer.setPassiveRegen(this.getPassiveRegen());
+    }
+
+    private double getBuffedHunterDoubleValue(String key, double defaultValue)
+    {
+        if (this.isJsonNotNull("buffed_hunter")) {
+            return this.jsonObject.get("buffed_hunter").getAsJsonObject().get(key).getAsJsonObject().get("value").getAsDouble();
+        }
+        return defaultValue;
+    }
+
+    private AttributeModifier.Operation getBuffedHunterAttributeModifier(String key, AttributeModifier.Operation defaultOperation)
+    {
+        if (this.isJsonNotNull("buffed_hunter")) {
+            return AttributeModifier.Operation.BY_ID.apply(this.jsonObject.get("buffed_hunter").getAsJsonObject().get(key).getAsJsonObject().get("modifier").getAsInt());
+        }
+        return defaultOperation;
+    }
+
+    public double getMaxHealthBonus() {
+        return getBuffedHunterDoubleValue("health", UMPlayer.getMaxHealthBonus());
+    }
+
+    public AttributeModifier.Operation getMaxHealthBonusModifier() {
+        return getBuffedHunterAttributeModifier("health", UMPlayer.getMaxHealthModifier());
+    }
+
+    public double getArmorBonus() {
+        return getBuffedHunterDoubleValue("armor", UMPlayer.getArmorBonus());
+    }
+
+    public AttributeModifier.Operation getArmorBonusModifier() {
+        return getBuffedHunterAttributeModifier("armor", UMPlayer.getArmorBonusModifier());
+    }
+
+    public double getMovementSpeedBonus() {
+        return getBuffedHunterDoubleValue("speed", UMPlayer.getMovementSpeedBonus());
+    }
+
+    public AttributeModifier.Operation getMovementSpeedBonusModifier() {
+        return getBuffedHunterAttributeModifier("speed", UMPlayer.getMovementSpeedBonusModifier());
+    }
+
+    public double getMovementEfficiencyBonus()
+    {
+        return getBuffedHunterDoubleValue("movement_efficiency", UMPlayer.getMovementEfficiencyBonus());
+    }
+
+    public AttributeModifier.Operation getMovementEfficiencyBonusModifier()
+    {
+        return getBuffedHunterAttributeModifier("movement_efficiency", UMPlayer.getMovementEfficiencyModifier());
+    }
+
+    public double getWaterMovementEfficiencyBonus()
+    {
+        return getBuffedHunterDoubleValue("water_movement_efficiency", UMPlayer.getWaterMovementEfficiencyBonus());
+    }
+
+    public AttributeModifier.Operation getWaterMovementEfficiencyBonusModifier()
+    {
+        return getBuffedHunterAttributeModifier("water_movement_efficiency", UMPlayer.getWaterMovementEfficiencyModifier());
+    }
+
+    public double getMiningEfficiencyBonus()
+    {
+        return getBuffedHunterDoubleValue("mining_efficiency", UMPlayer.getMiningEfficiencyBonus());
+    }
+
+    public AttributeModifier.Operation getMiningEfficiencyBonusModifier()
+    {
+        return getBuffedHunterAttributeModifier("mining_efficiency", UMPlayer.getMiningEfficiencyModifier());
+    }
+
+    public double getSubmergedMiningEfficiencyBonus()
+    {
+        return getBuffedHunterDoubleValue("submerged_mining_efficiency", UMPlayer.getSubmergedMiningEfficiencyBonus());
+    }
+
+    public AttributeModifier.Operation getSubmergedMiningEfficiencyBonusModifier()
+    {
+        return getBuffedHunterAttributeModifier("submerged_mining_efficiency", UMPlayer.getSubmergedMiningEfficiencyModifier());
+    }
+
+    public double getAttackDamageBonus() {
+        return getBuffedHunterDoubleValue("damage", UMPlayer.getAttackDamageBonus());
+    }
+
+    public AttributeModifier.Operation getAttackDamageBonusModifier() {
+        return getBuffedHunterAttributeModifier("damage", UMPlayer.getAttackDamageBonusModifier());
+    }
+
+    public boolean getHasInfiniteSaturation() {
+        if (this.isJsonNotNull("buffed_hunter")) {
+            return this.jsonObject.get("buffed_hunter").getAsJsonObject().get("saturation").getAsJsonObject().get("value").getAsBoolean();
+        }
+        return UMPlayer.getHasInfiniteSaturation();
+    }
+
+    public float getPassiveRegen()
+    {
+        if (this.isJsonNotNull("buffed_hunter"))
+        {
+            return this.jsonObject.get("buffed_hunter").getAsJsonObject().get("passive_regen").getAsJsonObject().get("value").getAsFloat();
+        }
+        return UMPlayer.getPassiveRegen();
+    }
+
+    @Override
+    protected String folderName() {
+        return "hunter_buffs";
+    }
+}


### PR DESCRIPTION
- Fixed player counter not updating correctly after a player leaves the game mid-round

- Tracker now updates every 0.25 seconds and uses interpolation for smoother motion.

- Added config settings for hunter buffs
  - All hunter buffs are configurable in-game using the sub-command "hunterBuffs".
  
- Fixed "game_profile" sub-command not properly overwriting settings for a game profile.

- Substantially decreased colored-tint screen effects for:
  - Hunter detection (red tint speed runners get when near a hunter)
  - Speed runner spawn protection (blue tint that appears after being killed by a hunter when not in hardcore mode)