### PR TITLE
Version 1.0.0 (1.21.1)

### DIFF
--- a/src/main/java/net/laserdiamond/ultimatemanhunt/commands/sub/HunterBuffsSC.java
+++ b/src/main/java/net/laserdiamond/ultimatemanhunt/commands/sub/HunterBuffsSC.java
@@ -2,6 +2,7 @@ package net.laserdiamond.ultimatemanhunt.commands.sub;
 
 import com.mojang.brigadier.arguments.BoolArgumentType;
 import com.mojang.brigadier.arguments.DoubleArgumentType;
+import com.mojang.brigadier.arguments.FloatArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.builder.LiteralArgumentBuilder;
 import com.mojang.brigadier.context.CommandContext;
@@ -33,6 +34,18 @@ public class HunterBuffsSC extends UltimateManhuntCommands.SubCommand {
                                                         createBuffArgs("movementSpeed", HunterBuffsSC::setSpeedBuff)
                                                 )
                                                 .then(
+                                                        createBuffArgs("movementEfficiency", HunterBuffsSC::setMovementEfficiencyBuff)
+                                                )
+                                                .then(
+                                                        createBuffArgs("waterMovementEfficiency", HunterBuffsSC::setWaterMovementEfficiencyBuff)
+                                                )
+                                                .then(
+                                                        createBuffArgs("miningEfficiency", HunterBuffsSC::setMiningEfficiencyBuff)
+                                                )
+                                                .then(
+                                                        createBuffArgs("submergedMiningEfficiency", HunterBuffsSC::setSubmergedMiningEfficiencyBuff)
+                                                )
+                                                .then(
                                                         createBuffArgs("attackDamage", HunterBuffsSC::setAttackDamageBuff)
                                                 )
                                                 .then(
@@ -40,6 +53,13 @@ public class HunterBuffsSC extends UltimateManhuntCommands.SubCommand {
                                                                 .then(
                                                                         Commands.argument("has_saturation", BoolArgumentType.bool())
                                                                                 .executes(context -> setSaturationBuff(context, BoolArgumentType.getBool(context, "has_saturation")))
+                                                                )
+                                                )
+                                                .then(
+                                                        Commands.literal("passiveRegen")
+                                                                .then(
+                                                                        Commands.argument("amount", FloatArgumentType.floatArg(0))
+                                                                                .executes(commandContext -> setPassiveRegenBuff(commandContext, FloatArgumentType.getFloat(commandContext, "amount")))
                                                                 )
                                                 )
                                 )
@@ -188,6 +208,58 @@ public class HunterBuffsSC extends UltimateManhuntCommands.SubCommand {
         return i;
     }
 
+    private static int setMovementEfficiencyBuff(CommandContext<CommandSourceStack> commandContext, double amount, AttributeModifier.Operation operation)
+    {
+        int i = 0;
+        if (UMPlayer.setMovementEfficiencyBonus(amount) && UMPlayer.setMovementEfficiencyBonusModifier(operation))
+        {
+            commandContext.getSource().sendFailure(Component.literal(ChatFormatting.RED + "Cannot change hunter buffs when a game has already been started!"));
+            return i;
+        }
+        commandContext.getSource().sendSuccess(() -> Component.literal("Set movement efficiency buff to: " + amount + " " + operation.name()), true);
+        i++;
+        return i;
+    }
+
+    private static int setWaterMovementEfficiencyBuff(CommandContext<CommandSourceStack> commandContext, double amount, AttributeModifier.Operation operation)
+    {
+        int i = 0;
+        if (UMPlayer.setWaterMovementEfficiencyBonus(amount) && UMPlayer.setWaterMovementEfficiencyBonusModifier(operation))
+        {
+            commandContext.getSource().sendFailure(Component.literal(ChatFormatting.RED + "Cannot change hunter buffs when a game has already been started!"));
+            return i;
+        }
+        commandContext.getSource().sendSuccess(() -> Component.literal("Set water movement efficiency buff to: " + amount + " " + operation.name()), true);
+        i++;
+        return i;
+    }
+
+    private static int setMiningEfficiencyBuff(CommandContext<CommandSourceStack> commandContext, double amount, AttributeModifier.Operation operation)
+    {
+        int i = 0;
+        if (UMPlayer.setMiningEfficiencyBonus(amount) && UMPlayer.setMiningEfficiencyBonusModifier(operation))
+        {
+            commandContext.getSource().sendFailure(Component.literal(ChatFormatting.RED + "Cannot change hunter buffs when a game has already been started!"));
+            return i;
+        }
+        commandContext.getSource().sendSuccess(() -> Component.literal("Set mining efficiency buff to: " + amount + " " + operation.name()), true);
+        i++;
+        return i;
+    }
+
+    private static int setSubmergedMiningEfficiencyBuff(CommandContext<CommandSourceStack> commandContext, double amount, AttributeModifier.Operation operation)
+    {
+        int i = 0;
+        if (UMPlayer.setSubmergedMiningEfficiencyBonus(amount) && UMPlayer.setSubmergedMiningEfficiencyBonusModifier(operation))
+        {
+            commandContext.getSource().sendFailure(Component.literal(ChatFormatting.RED + "Cannot change hunter buffs when a game has already been started!"));
+            return i;
+        }
+        commandContext.getSource().sendSuccess(() -> Component.literal("Set submerged mining efficiency buff to: " + amount + " " + operation.name()), true);
+        i++;
+        return i;
+    }
+
     private static int setSaturationBuff(CommandContext<CommandSourceStack> commandContext, boolean hasSaturation)
     {
         int i = 0;
@@ -197,6 +269,19 @@ public class HunterBuffsSC extends UltimateManhuntCommands.SubCommand {
             return i;
         }
         commandContext.getSource().sendSuccess(() -> Component.literal("Set hunter saturation to: " + hasSaturation), true);
+        i++;
+        return i;
+    }
+
+    private static int setPassiveRegenBuff(CommandContext<CommandSourceStack> commandContext, float amount)
+    {
+        int i = 0;
+        if (UMPlayer.setPassiveRegen(amount))
+        {
+            commandContext.getSource().sendFailure(Component.literal(ChatFormatting.RED + "Cannot change hunter buffs when a game has already been started!"));
+            return i;
+        }
+        commandContext.getSource().sendSuccess(() -> Component.literal("Set hunter passive regen to: " + amount), true);
         i++;
         return i;
     }


### PR DESCRIPTION
- Fixed player counter not updating correctly after a player leaves the game mid-round

- Tracker now updates every 0.25 seconds and uses interpolation for smoother motion.

- Added config settings for hunter buffs
  - All hunter buffs are configurable in-game using the sub-command "hunterBuffs".

- Fixed "game_profile" sub-command not properly overwriting settings for a game profile.

- Substantially decreased colored-tint screen effects for:
  - Hunter detection (red tint speed runners get when near a hunter)
  - Speed runner spawn protection (blue tint that appears after being killed by a hunter when not in hardcore mode)